### PR TITLE
Spaces in project names

### DIFF
--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -120,7 +120,7 @@ class OmniFocus
     prefixen = self.class._plugins.map { |klass| klass::PREFIX rescue nil }
     of_tasks = nil
 
-    prefix_re = /^(#{Regexp.union prefixen}(?:-[\w.-]+)?\#\d+)/
+    prefix_re = /^(#{Regexp.union prefixen}(?:-[\w\s.-]+)?\#\d+)/
 
     if prefixen.all? then
       of_tasks = all_tasks.find_all { |task|


### PR DESCRIPTION
Hi!

I have some projects that have space character in their name and this breaks the syncing of tasks. Tasks get generated but they are not found on the re-syncing so they are regenerated.

I investigated a bit and the problem can be fixed by changing the regular expression here: https://github.com/seattlerb/omnifocus/blob/master/lib/omnifocus.rb#L123

I'm too weak with regular expressions but will get it done if a patch is OK for you. I use only Github and Pivotal Tracker integrations so I don't know if there might be some integrations that would be affected badly by this change (adding space as a supported character in the project name).

Thanks in advance!
