### PR TITLE
Kill warnings

### DIFF
--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -715,7 +715,7 @@ class OmniFocus
   end
 
   def aggregate collection
-    h = Hash.new { |h,k| h[k] = Hash.new { |h2,k2| h2[k2] = [] } }
+    h = Hash.new { |h1,k1| h1[k1] = Hash.new { |h2,k2| h2[k2] = [] } }
     p = Hash.new 0
 
     collection.each do |thing|


### PR DESCRIPTION
After updating to Ruby 2.0, Ruby runtime complains about some parts in omnifocus.rb.

```
lib/omnifocus.rb:386: warning: assigned but unused variable - of
lib/omnifocus.rb:400: warning: assigned but unused variable - name
lib/omnifocus.rb:720: warning: shadowing outer local variable - h
```

This PR simply suppress them and harmless.
