### PR TITLE
Fix unicode handling

### DIFF
--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -162,7 +162,13 @@ class OmniFocus
   # the nerd folder.
 
   def create_missing_projects
-    (bug_db.keys - nerd_projects.projects.name.get).each do |name|
+    projects_name = []
+    nerd_projects.projects.name.get.each do |proj|
+      proj_name = proj
+      proj_name.force_encoding("UTF-8")
+      projects_name << proj_name
+    end
+    (bug_db.keys - projects_name).each do |name|
       warn "creating project #{name}"
       next if $DEBUG
       make nerd_projects, :project, name


### PR DESCRIPTION
omnifocus.rb lacks proper support over non-ASCII project names. Fundamentally, this is an issue of AppScript ruby binding, but it's not maintained any longer and I don't want to touch inside of them (first off, AppScript is Carbon backed and Apple doesn't port them to Cocoa based. So, it's a heritage and it's natural to keep away from maintaing it).

With this PR, you can
- create non-ASCII named projects properly
- create/delete non-ASCII named tasks properly under ASCII or non-ASCII named projects

Implementation suggestions are welcomed because I don't know much about Ruby manner (maybe there're better ways to apply UTF-8 on all text).
