### PR TITLE
Adding support for hash parameter to make

### DIFF
--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -33,9 +33,9 @@ class OmniFocus
   ##
   # bug_db = {
   #   project => {
-  #     bts_id => [task_name, url], # only on BTS     = add to OF
-  #     bts_id => true,             # both BTS and OF = don't touch
-  #     bts_id => false,            # only on OF      = remove from OF
+  # bts_id => [task_name, url, due, defer], # only on BTS     = add to OF
+  # bts_id => {field=>value, ...},          # only on BTS     = OF and maybe BTS. Update fields
+  # bts_id => true,                         # both BTS and OF = don't touch
   #   }
   # }
 
@@ -94,7 +94,8 @@ class OmniFocus
   # Utility shortcut to make a new thing with a name via appscript.
 
   def make target, type, name, extra = {}
-    target.make :new => type, :with_properties => { :name => name }.merge(extra)
+    properties = { :name => name }.merge(extra)
+    target.make :new => type, :with_properties => properties
   end
 
   ##
@@ -195,6 +196,12 @@ class OmniFocus
           next if $DEBUG
           title, url = *value
           make project, :task, title, :note => url
+        when Hash
+          puts "Adding Detail #{project_name} # #{bts_id} #{$DEBUG}"
+          next if $DEBUG
+          properties = value.clone
+          title = properties.delete(:title)
+          make project, :task, title, properties
         else
           abort "ERROR: Unknown value in bug_db #{bts_id}: #{value.inspect}"
         end

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -33,9 +33,9 @@ class OmniFocus
   ##
   # bug_db = {
   #   project => {
-  # bts_id => [task_name, url, due, defer], # only on BTS     = add to OF
-  # bts_id => {field=>value, ...},          # only on BTS     = OF and maybe BTS. Update fields
-  # bts_id => true,                         # both BTS and OF = don't touch
+  #   bts_id => [task_name, url, due, defer], # only on BTS     = add to OF
+  #   bts_id => {field=>value, ...},          # only on BTS     = OF and maybe BTS. Update fields
+  #   bts_id => true,                         # both BTS and OF = don't touch
   #   }
   # }
 

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -171,15 +171,15 @@ class OmniFocus
   # for +bug_db+ for more info on how you should populate it.
 
   def update_tasks
-    bug_db.each do |project_name, tickets|
-      project = nerd_projects.projects[project_name]
+    bug_db.each do |name, tickets|
+      project = nerd_projects.projects[name]
 
       tickets.each do |bts_id, value|
         case value
         when true
           project.tasks[its.name.contains(bts_id)].get.each do |task|
             if task.completed.get
-              puts "Re-opening #{project_name} # #{bts_id}"
+              puts "Re-opening #{name} # #{bts_id}"
               next if $DEBUG
               task.completed.set false
             end
@@ -187,17 +187,17 @@ class OmniFocus
         when false
           project.tasks[its.name.contains(bts_id)].get.each do |task|
             next if task.completed.get
-            puts "Removing #{project_name} # #{bts_id}"
+            puts "Removing #{name} # #{bts_id}"
             next if $DEBUG
             task.completed.set true
           end
         when Array
-          puts "Adding #{project_name} # #{bts_id}"
+          puts "Adding #{name} # #{bts_id}"
           next if $DEBUG
           title, url = *value
           make project, :task, title, :note => url
         when Hash
-          puts "Adding Detail #{project_name} # #{bts_id}"
+          puts "Adding Detail #{name} # #{bts_id}"
           next if $DEBUG
           properties = value.clone
           title = properties.delete(:title)

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -197,7 +197,7 @@ class OmniFocus
           title, url = *value
           make project, :task, title, :note => url
         when Hash
-          puts "Adding Detail #{project_name} # #{bts_id} #{$DEBUG}"
+          puts "Adding Detail #{project_name} # #{bts_id}"
           next if $DEBUG
           properties = value.clone
           title = properties.delete(:title)

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -170,15 +170,15 @@ class OmniFocus
   # for +bug_db+ for more info on how you should populate it.
 
   def update_tasks
-    bug_db.each do |name, tickets|
-      project = nerd_projects.projects[name]
+    bug_db.each do |project_name, tickets|
+      project = nerd_projects.projects[project_name]
 
       tickets.each do |bts_id, value|
         case value
         when true
           project.tasks[its.name.contains(bts_id)].get.each do |task|
             if task.completed.get
-              puts "Re-opening #{name} # #{bts_id}"
+              puts "Re-opening #{project_name} # #{bts_id}"
               next if $DEBUG
               task.completed.set false
             end
@@ -186,12 +186,12 @@ class OmniFocus
         when false
           project.tasks[its.name.contains(bts_id)].get.each do |task|
             next if task.completed.get
-            puts "Removing #{name} # #{bts_id}"
+            puts "Removing #{project_name} # #{bts_id}"
             next if $DEBUG
             task.completed.set true
           end
         when Array
-          puts "Adding #{name} # #{bts_id}"
+          puts "Adding #{project_name} # #{bts_id}"
           next if $DEBUG
           title, url = *value
           make project, :task, title, :note => url

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -33,9 +33,9 @@ class OmniFocus
   ##
   # bug_db = {
   #   project => {
-  #   bts_id => [task_name, url, due, defer], # only on BTS     = add to OF
-  #   bts_id => {field=>value, ...},          # only on BTS     = OF and maybe BTS. Update fields
-  #   bts_id => true,                         # both BTS and OF = don't touch
+  #     bts_id => [task_name, url, due, defer], # only on BTS     = add to OF
+  #     bts_id => {field=>value, ...},          # only on BTS     = OF and maybe BTS. Update fields
+  #     bts_id => true,                         # both BTS and OF = don't touch
   #   }
   # }
 

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -94,8 +94,7 @@ class OmniFocus
   # Utility shortcut to make a new thing with a name via appscript.
 
   def make target, type, name, extra = {}
-    properties = { :name => name }.merge(extra)
-    target.make :new => type, :with_properties => properties
+    target.make :new => type, :with_properties => { :name => name }.merge(extra)
   end
 
   ##


### PR DESCRIPTION
This patch allows me to write a plugin where I pass fields other than note and title, such as due_date.
By adding a new case, backwards compatibility with existing plugins is maintained. 