### PR TITLE
Stopping when Ruby vsn is greater than 2.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Hoe.spec "omnifocus" do
 
   license "MIT"
 
-  dependency "rb-appscript", "~> 0.6.1"
+  dependency "rb-scpt", "~> 1.0.1"
   dependency "mechanize",    "~> 2.0"
   dependency "octokit",   "~> 2.0", :development if ENV["TEST"]
 

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'appscript'
+require 'rb-scpt'
 
 NERD_FOLDER = ENV["OF_FOLDER"] || "nerd"
 
@@ -14,7 +14,7 @@ class Appscript::Reference # :nodoc:
   def to_ary # :nodoc:
     nil
   end
-end if RUBY_VERSION >= "1.9" || < "2.2"
+end if RUBY_VERSION >= "1.9"
 
 include Appscript
 

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -14,7 +14,7 @@ class Appscript::Reference # :nodoc:
   def to_ary # :nodoc:
     nil
   end
-end if RUBY_VERSION >= "1.9"
+end if RUBY_VERSION >= "1.9" || < "2.2"
 
 include Appscript
 


### PR DESCRIPTION
Because of `rb-appscript` dependency, this gem breaks on any Ruby version greater than 2.2. (See issue [here](https://github.com/mattneub/appscript/issues/12).) Per the maintainers of `rb-appscript`, Eric suggested using [`rb-scpt`](https://github.com/BrendanThompson/rb-scpt), since it was compatible with Ruby 2.2.

I was going to update the dependencies myself, but I was unsure if all I needed to do was update the dependency in the Hoe block. If that's all that is needed, I can update this PR.
