### PR TITLE
GitHub tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/tmp/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) Ryan Davis, seattle.rb
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Omnifocus
+
+> Synchronizes bug tracking systems to omnifocus.
+
+[home](https://github.com/seattlerb/omnifocus)
+[rdoc](http://docs.seattlerb.org/omnifocus)
+
+## FEATURES/PROBLEMS:
+
+* Pluggable to work with multiple bug tracking systems (BTS).
+* Creates projects in omnifocus if needed.
+* Creates tasks for multiple projects in omnifocus.
+* Marks tasks complete if they've been closed in the BTS.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'omnifocus'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+	$ sudo gem install omnifocus
+
+
+## REQUIREMENTS:
+
+* mechanize
+* rb-appscript
+
+## SYNOPSIS:
+
+```
+% of sync
+scanning ticket RF#3802
+removing parsetree # 314159
+creating parsetree # 3802
+...
+```
+
+## Known Plugins:
+
++ omnifocus-bugzilla       by kushali
++ omnifocus-github         by zenspider
++ omnifocus-pivotaltracker by vesan
++ omnifocus-redmine        by kushali
++ omnifocus-rt             by kushali
++ omnifocus-rubyforge      by zenspider
++ omnifocus-lighthouse     by juliengrimault
++ omnifocus-trello         by vesan
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
- Adds a License text file that allows the license to be picked up by github's scanner
    - The license could be removed from README.txt if desired
- Adds a markdown readme for better formatting on page
- Adds a gitignore file for this repo

You can see the readme / license pickup by looking at my fork: https://github.com/mcordell/omnifocus