### PR TITLE
record dateLastActivity in trello card in update hash structure to let the plugin to update task

### DIFF
--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -48,6 +48,7 @@ class OmniFocus
   # }
 
   attr_reader :existing
+  attr_reader :update
 
   ##
   # Load any file matching "omnifocus/*.rb"
@@ -71,6 +72,7 @@ class OmniFocus
   def initialize
     @bug_db   = Hash.new { |h,k| h[k] = {} }
     @existing = {}
+    @update =   {}
   end
 
   def its # :nodoc:
@@ -141,6 +143,7 @@ class OmniFocus
       ticket_id = of_task.name.get[prefix_re, 1]
       project                    = of_task.containing_project.name.get
       existing[ticket_id]        = project
+      update[ticket_id]          = of_task.note.get.lines.first
       bug_db[project][ticket_id] = false
     end
   end

--- a/lib/omnifocus.rb
+++ b/lib/omnifocus.rb
@@ -123,7 +123,7 @@ class OmniFocus
     prefixen = self.class._plugins.map { |klass| klass::PREFIX rescue nil }
     of_tasks = nil
 
-    prefix_re = /^(#{Regexp.union prefixen}(?:-[\w\s.-]+)?\#\d+)/
+    prefix_re = /^(#{Regexp.union prefixen}(?:-[\w\s\p{Han}.-]+)?\#\d+)/
 
     if prefixen.all? then
       of_tasks = all_tasks.find_all { |task|


### PR DESCRIPTION
So once we update card in the trello, such as change card name, set label , we can update card/task in omnifocus according the change of  dateLastActivity of card/task.   

The omnifocus-trello will use the update hash var to decide whether first delete the task and readd the task  or only add the task. 

add mini fix for the chinese list name support.

