### PR TITLE
Fix "Known Plugins" in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,14 +24,14 @@ Synchronizes bug tracking systems to omnifocus.
 
 == Known Plugins:
 
-+ omnifocus-bugzilla       by kushali
-+ omnifocus-github         by zenspider
-+ omnifocus-pivotaltracker by vesan
-+ omnifocus-redmine        by kushali
-+ omnifocus-rt             by kushali
-+ omnifocus-rubyforge      by zenspider
-+ omnifocus-lighthouse     by juliengrimault
-+ omnifocus-trello         by vesan
+* omnifocus-bugzilla       by kushali
+* omnifocus-github         by zenspider
+* omnifocus-pivotaltracker by vesan
+* omnifocus-redmine        by kushali
+* omnifocus-rt             by kushali
+* omnifocus-rubyforge      by zenspider
+* omnifocus-lighthouse     by juliengrimault
+* omnifocus-trello         by vesan
 
 == REQUIREMENTS:
 


### PR DESCRIPTION
According to [rdoc markdown documentation](https://github.com/ruby/rdoc/blob/master/test/rdoc/MarkdownTest_1.0.3/Markdown%20Documentation%20-%20Syntax.text), "+" "-" and "*" are equivalent

however the list is not displayed right both on [github README page](https://github.com/seattlerb/omnifocus#label-Known+Plugins-3A) and [doc page](http://docs.seattlerb.org/omnifocus/#label-Known+Plugins-3A)

![image](https://user-images.githubusercontent.com/48843657/180758549-527c0ee4-fecc-47ba-ab94-c8af177bcbb8.png)
![image](https://user-images.githubusercontent.com/48843657/180758591-adb731f1-1377-4cff-a4db-808010185b3d.png)
